### PR TITLE
Fix bug with number of transactions synced

### DIFF
--- a/financas_automatizadas/main.py
+++ b/financas_automatizadas/main.py
@@ -61,9 +61,9 @@ def main() -> [dict]:
         created_transactions += transactions_to_ynab
 
     print("######")
-    print(f"SYNCED {len(transactions)} TRANSACTIONS")
+    print(f"SYNCED {len(created_transactions)} TRANSACTIONS")
     print("######")
-    return transactions
+    return created_transactions
 
 
 

--- a/financas_automatizadas/main.py
+++ b/financas_automatizadas/main.py
@@ -42,7 +42,7 @@ def main() -> [dict]:
         },
     ]
 
-    transactions = {}
+    created_transactions = []
     for account_id_pair in account_id_pairs:
         print("######")
         print(f'SYNCING {account_id_pair["name"]}')
@@ -53,12 +53,12 @@ def main() -> [dict]:
             api_key=api_key,
         )
 
-        transactions.append(
-            ynab.send_transactions_to_ynab(
-                transactions=transactions,
-                account_id=account_id_pair["ynab"],
-            )
+        transactions_to_ynab = ynab.send_transactions_to_ynab(
+            transactions=transactions,
+            account_id=account_id_pair["ynab"],
         )
+
+        created_transactions += transactions_to_ynab
 
     print("######")
     print(f"SYNCED {len(transactions)} TRANSACTIONS")


### PR DESCRIPTION
Tem um pequeno bug com o código: se não tem transações sincronizadas, ele sempre vai reportar `SYNCED 0 TRANSACTIONS` porque este:

```
        transactions.append(
            ynab.send_transactions_to_ynab(
                transactions=transactions,
                account_id=account_id_pair["ynab"],
            )
        )
```

vai resultar em `transactions = {[]}`

Este PR é independente de #15 . MAS, não podia testar (porque não tenho seu secrets) 

